### PR TITLE
implement frontend caching for movie API responses

### DIFF
--- a/imdb-frontend/src/App.tsx
+++ b/imdb-frontend/src/App.tsx
@@ -1,8 +1,10 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import MovieSearch from "./components/MovieSearch";
 import MovieDetails from "./components/MovieDetails";
+import { useInvalidateCache } from "./hooks/useInvalidateCache";
 
 const App = () => {
+  useInvalidateCache(30); // Clear cache every 30 minutes
   return (
     <Router>
       <div className="container mx-auto">

--- a/imdb-frontend/src/components/MovieSearch.tsx
+++ b/imdb-frontend/src/components/MovieSearch.tsx
@@ -12,6 +12,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { movieCache } from "../utils/cache";
 
 const MovieSearch = () => {
   const [movies, setMovies] = useState<MovieSearchResultType[]>([]);
@@ -20,6 +21,7 @@ const MovieSearch = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [totalResults, setTotalResults] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
+  const [isCached, setIsCached] = useState(false);
 
   const moviesPerPage = 10; // OMDB API returns 10 results per page
   const totalPages = Math.ceil(totalResults / moviesPerPage);
@@ -30,6 +32,10 @@ const MovieSearch = () => {
     setSearchQuery(query);
 
     try {
+      const cacheKey = movieCache.createKey(query, page);
+      const cachedExists = movieCache.get(cacheKey) !== null;
+      setIsCached(cachedExists);
+
       const data = await searchMovies(query, page);
       setMovies(data.Search || []);
       setTotalResults(parseInt(data.totalResults) || 0);
@@ -96,6 +102,9 @@ const MovieSearch = () => {
   return (
     <div className="w-full max-w-7xl mx-auto p-6">
       <SearchBar onSearch={(query) => handleSearch(query, 1)} />
+      {isCached && (
+        <p className="text-sm text-gray-500 mb-2">Results loaded from cache</p>
+      )}
       {error && <p className="text-red-500 mb-4">{error}</p>}
       <MovieList movies={movies} isLoading={isLoading} />
 

--- a/imdb-frontend/src/hooks/useInvalidateCache.ts
+++ b/imdb-frontend/src/hooks/useInvalidateCache.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { movieCache } from "../utils/cache";
+
+export const useInvalidateCache = (invalidationTimeMinutes: number = 30) => {
+  useEffect(() => {
+    const interval = setInterval(() => {
+      movieCache.clear();
+    }, invalidationTimeMinutes * 60 * 1000);
+
+    return () => clearInterval(interval);
+  }, [invalidationTimeMinutes]);
+};

--- a/imdb-frontend/src/services/api.ts
+++ b/imdb-frontend/src/services/api.ts
@@ -1,18 +1,38 @@
 import axios from "axios";
+import { movieCache } from "../utils/cache";
 
 const API_URL = import.meta.env.VITE_API_URL;
 
 export const searchMovies = async (query: string, page: number = 1) => {
+  const cacheKey = movieCache.createKey(query, page);
+  const cachedData = movieCache.get(cacheKey);
+
+  if (cachedData) {
+    console.log("Returning cached data for:", query, page);
+    return cachedData;
+  }
+
   const response = await axios.get(`${API_URL}/movies/search`, {
     params: {
       query,
       page,
     },
   });
+
+  movieCache.set(cacheKey, response.data);
   return response.data;
 };
 
 export const getMovieDetails = async (id: string) => {
+  const cacheKey = `movie-${id}`;
+  const cachedData = movieCache.get(cacheKey);
+
+  if (cachedData) {
+    console.log("Returning cached movie details for:", id);
+    return cachedData;
+  }
+
   const response = await axios.get(`${API_URL}/movies/${id}`);
+  movieCache.set(cacheKey, response.data);
   return response.data;
 };

--- a/imdb-frontend/src/utils/cache.ts
+++ b/imdb-frontend/src/utils/cache.ts
@@ -1,0 +1,47 @@
+interface CacheItem<T> {
+  data: T;
+  timestamp: number;
+}
+
+interface Cache {
+  [key: string]: CacheItem<any>;
+}
+
+export class ApiCache {
+  private cache: Cache = {};
+  private readonly ttl: number; // Time to live in milliseconds
+
+  constructor(ttlMinutes: number = 5) {
+    this.ttl = ttlMinutes * 60 * 1000;
+  }
+
+  createKey(query: string, page: number): string {
+    return `${query}-${page}`;
+  }
+
+  get<T>(key: string): T | null {
+    const item = this.cache[key];
+    if (!item) return null;
+
+    const now = Date.now();
+    if (now - item.timestamp > this.ttl) {
+      delete this.cache[key];
+      return null;
+    }
+
+    return item.data;
+  }
+
+  set<T>(key: string, data: T): void {
+    this.cache[key] = {
+      data,
+      timestamp: Date.now(),
+    };
+  }
+
+  clear(): void {
+    this.cache = {};
+  }
+}
+
+export const movieCache = new ApiCache(5); // Cache for 5 minutes


### PR DESCRIPTION
Add cache utility with TTL for movie searches and details.
Store API responses using unique key-value pairs.
Reduce redundant API calls and improve load times.